### PR TITLE
Log4j Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,26 @@ plugins {
     id "org.sonarqube" version "3.1"
 }
 
+dependencies {
+    compile "ch.qos.logback:logback-classic:1.2.10"
+    compile "ch.qos.logback:logback-core:1.2.10"
+    
+    constraints {
+      implementation('org.apache.logging.log4j:log4j-core:2.17.1') {
+        because 'Log4j vulnerable to remote code execution and other critical security vulnerabilities'
+      }
+      implementation('org.apache.logging.log4j:log4j-api:2.17.1') {
+        because 'Log4j vulnerable to remote code execution and other critical security vulnerabilities'
+      }
+      implementation('ch.qos.logback:logback-classic:1.2.10') {
+        because 'Logback vulnerable to remote code execution and other critical security vulnerabilities'
+      }
+      implementation('ch.qos.logback:logback-core:1.2.10') {
+        because 'Logback vulnerable to remote code execution and other critical security vulnerabilities'
+      }
+    }
+}
+
 subprojects { project ->
 	boolean isGrailsApp = project.name.endsWith( '-app' )
 	boolean isGrailsPlugin = project.name.endsWith( '-plugin' )

--- a/build.gradle
+++ b/build.gradle
@@ -144,20 +144,10 @@ subprojects { project ->
             testCompile "org.mockito:mockito-core"
             testCompile "org.grails:grails-web-testing-support"
 	    
-	    constraints {
-      		implementation('org.apache.logging.log4j:log4j-core:2.17.1') {
-        		because 'Log4j vulnerable to remote code execution and other critical security vulnerabilities'
-      		}
-      		implementation('org.apache.logging.log4j:log4j-api:2.17.1') {
-        		because 'Log4j vulnerable to remote code execution and other critical security vulnerabilities'
-      		}
-      		implementation('ch.qos.logback:logback-classic:1.2.10') {
-        		because 'Logback vulnerable to remote code execution and other critical security vulnerabilities'
-      		}
-      		implementation('ch.qos.logback:logback-core:1.2.10') {
-        		because 'Logback vulnerable to remote code execution and other critical security vulnerabilities'
-      		}
-    	    }
+	    compile "org.apache.logging.log4j:log4j-to-slf4j:2.17.1"
+            compile "org.apache.logging.log4j:log4j-api:2.17.1"
+            compile "ch.qos.logback:logback-classic:1.2.10"
+            compile "ch.qos.logback:logback-core:1.2.10"
 
             if ( isGrailsApp )
             {

--- a/build.gradle
+++ b/build.gradle
@@ -17,26 +17,6 @@ plugins {
     id "org.sonarqube" version "3.1"
 }
 
-dependencies {
-    compile "ch.qos.logback:logback-classic:1.2.10"
-    compile "ch.qos.logback:logback-core:1.2.10"
-    
-    constraints {
-      implementation('org.apache.logging.log4j:log4j-core:2.17.1') {
-        because 'Log4j vulnerable to remote code execution and other critical security vulnerabilities'
-      }
-      implementation('org.apache.logging.log4j:log4j-api:2.17.1') {
-        because 'Log4j vulnerable to remote code execution and other critical security vulnerabilities'
-      }
-      implementation('ch.qos.logback:logback-classic:1.2.10') {
-        because 'Logback vulnerable to remote code execution and other critical security vulnerabilities'
-      }
-      implementation('ch.qos.logback:logback-core:1.2.10') {
-        because 'Logback vulnerable to remote code execution and other critical security vulnerabilities'
-      }
-    }
-}
-
 subprojects { project ->
 	boolean isGrailsApp = project.name.endsWith( '-app' )
 	boolean isGrailsPlugin = project.name.endsWith( '-plugin' )
@@ -163,6 +143,21 @@ subprojects { project ->
             testCompile "org.grails:grails-gorm-testing-support"
             testCompile "org.mockito:mockito-core"
             testCompile "org.grails:grails-web-testing-support"
+	    
+	    constraints {
+      		implementation('org.apache.logging.log4j:log4j-core:2.17.1') {
+        		because 'Log4j vulnerable to remote code execution and other critical security vulnerabilities'
+      		}
+      		implementation('org.apache.logging.log4j:log4j-api:2.17.1') {
+        		because 'Log4j vulnerable to remote code execution and other critical security vulnerabilities'
+      		}
+      		implementation('ch.qos.logback:logback-classic:1.2.10') {
+        		because 'Logback vulnerable to remote code execution and other critical security vulnerabilities'
+      		}
+      		implementation('ch.qos.logback:logback-core:1.2.10') {
+        		because 'Logback vulnerable to remote code execution and other critical security vulnerabilities'
+      		}
+    	    }
 
             if ( isGrailsApp )
             {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-buildVersion=2.0.7
+buildVersion=2.0.8
 
 grailsVersion=4.0.6
 gorm.version=7.0.8.RELEASE


### PR DESCRIPTION
Updated the dependency constraints and bumped the build version. Did not need to update the logback.groovy as it is excluded and not in the repo. 